### PR TITLE
Fixed command to create a vite project for playground.

### DIFF
--- a/book/online-book/src/00-introduction/040-setup-project.md
+++ b/book/online-book/src/00-introduction/040-setup-project.md
@@ -146,7 +146,7 @@ export const helloChibivue = () => {
 pwd # ~/
 mkdir examples
 cd examples
-nlx create vite
+nlx create-vite
 
 ## --------- create vite cliの設定
 ## Project name: playground

--- a/book/online-book/src/en/00-introduction/040-setup-project.md
+++ b/book/online-book/src/en/00-introduction/040-setup-project.md
@@ -131,7 +131,7 @@ export const helloChibivue = () => {
 pwd # ~/
 mkdir examples
 cd examples
-nlx create vite
+nlx create-vite
 
 ## --------- Setting up with the Vite CLI
 ## Project name: playground


### PR DESCRIPTION
During the execution of the steps in the playground setup section of the book, the command `nlx create vite`, the following error occurred:
    
> プレイグラウンド側の構築
> ```sh
> nlx create vite
> ```
> https://ubugeeei.github.io/chibivue/00-introduction/040-setup-project.html#%E3%83%95%E3%82%9A%E3%83%AC%E3%82%A4%E3%82%AF%E3%82%99%E3%83%A9%E3%82%A6%E3%83%B3%E3%83%88%E3%82%99%E5%81%B4%E3%81%AE%E6%A7%8B%E7%AF%89

```sh
$ nlx create vite
Packages: +1
+
Progress: resolved 1, reused 1, downloaded 0, added 1, done
 ERR_PNPM_DLX_NO_BIN  No binaries found in create
```

This is probably due to the fact that `ni` does not support the `npm create` equivalent.

`npm init(create)` is a `npx` wapper supported by `ni`, so I changed it to run with `nlx create-vite`.

> The init command is transformed to a corresponding npm exec operation as follows:
>
> * `npm init foo` -> npm exec create-foo
>
> https://docs.npmjs.com/cli/v10/commands/npm-init#description

```sh
$ nlx create-vite
Packages: +1
+
Progress: resolved 1, reused 1, downloaded 0, added 1, done
✔ Project name: … playground
✔ Select a framework: › Vanilla
✔ Select a variant: › TypeScript

Scaffolding project in learn-chibivue/examples/playground...

Done. Now run:

  cd playground
  pnpm install
  pnpm run dev
```

My local environment is as follows:

```sh
$ node -v
v18.18.2
$ pnpm list | grep vite
vite 4.4.11
```