### PR TITLE
fixed inline code syntax highlighting.

### DIFF
--- a/book/online-book/src/10-minimum-example/020-simple-h-function.md
+++ b/book/online-book/src/10-minimum-example/020-simple-h-function.md
@@ -147,7 +147,7 @@ mount(rootContainer: HostElement) {
 ```
 
 それでは、render 関数を実装してみましょう。
-RendererOptions に  createElement` と `createText` と `insert` を実装します。
+RendererOptions に `createElement` と `createText` と `insert` を実装します。
 
 ```ts
 export interface RendererOptions<HostNode = RendererNode> {


### PR DESCRIPTION
I fixed the incorrect inline code syntax highlighting in accordance with the English document.

> それでは、render 関数を実装してみましょう。 RendererOptions に createElementとcreateTextとinsert` を実装します。
> https://ubugeeei.github.io/chibivue/10-minimum-example/020-simple-h-function.html#h-function-%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B

> Now, let's implement the render function. Implement createElement, createText, and insert in RendererOptions.
> https://ubugeeei.github.io/chibivue/en/10-minimum-example/020-simple-h-function.html#implementing-the-h-function