### PR TITLE
Add step for modifying tsconfig.json to Setup Project.

### DIFF
--- a/book/online-book/src/00-introduction/040-setup-project.md
+++ b/book/online-book/src/00-introduction/040-setup-project.md
@@ -212,6 +212,40 @@ export default defineConfig({
 });
 ```
 
+tsconfig.json の中身を以下のように書き換えます。
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "paths": {
+      "chibivue": [
+        "../../packages"
+      ],
+    }
+  },
+  "include": [
+    "src"
+  ]
+}
+```
+
 最後に、chibivue プロジェクトの package.json に playground を起動するコマンドを記述して実際に起動してみましよう！
 
 ~/package.json に以下を追記

--- a/book/online-book/src/en/00-introduction/040-setup-project.md
+++ b/book/online-book/src/en/00-introduction/040-setup-project.md
@@ -198,6 +198,40 @@ export default defineConfig({
 });
 ```
 
+Modify tsconfig.json as follows.
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "paths": {
+      "chibivue": [
+        "../../packages"
+      ],
+    }
+  },
+  "include": [
+    "src"
+  ]
+}
+```
+
 Lastly, let's add a command to the package.json of the chibivue project to launch the playground and try starting it!
 
 Append the following to ~/package.json


### PR DESCRIPTION
The following playground setup procedure uses the default `tsconfig.json` of `nlx create-vite` as is.

https://ubugeeei.github.io/chibivue/00-introduction/040-setup-project.html#プレイグラウンド側の構築

However, the default `tsconfig.json` does not recognize `chibivue` as an alias, as shown below,

```sh
mkdir examples
cd examples
nlx create-vite
cat examples/playground/tsconfig.json
{
  "compilerOptions": {
    "target": "ES2020", { "compilerOptions": { "compilerOptions": { "compilerOptions".

    "skipLibCheck": true,.

    /* Bundler mode */
    "moduleResolution": "bundler", /* Bundler mode */.

    "resolveJsonModule": true, /* Bundler mode */ "moduleResolution": "bundler", "allowImportingTsExtensions": true, "resolveJsonModule": true, "resolveJsonModule": true
    "isolatedModules": true, "noEmit": true, "noEmit": true, "noEmit": true, "noEmit": true
    "noEmit": true,.

    /* Linting */
    "strict": true, "noUnusedLocals": true, /* Linting */.

    "noFallthroughCasesInSwitch": true
  }, }
  "include": ["src"]
}
```

Added step for modifying `tsconfig.json` to match the following sample code.

https://github.com/Ubugeeei/chibivue/blob/65ee4f995f3717f32790dd6d93aaa5819f4417d8/book/impls/00_introduction/010_project_setup/examples/playground/tsconfig.json