### PR TITLE
fixed typo for enabled colored diffs in code blocks.

### DIFF
--- a/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
@@ -235,7 +235,7 @@ export interface VNode<HostNode = RendererNode> {
   type: VNodeTypes;
   props: VNodeProps | null;
   children: VNodeNormalizedChildren;
-  el: HostNode | undefined; // [!code++]
+  el: HostNode | undefined; // [!code ++]
 }
 ```
 


### PR DESCRIPTION
Fixed typo in comment for code block diff for minimum virtual DOM.

> ```ts
> export interface VNode<HostNode = RendererNode> {
>  type: VNodeTypes;
>  props: VNodeProps | null;
>  children: VNodeNormalizedChildren;
>  el: HostNode | undefined; // [!code++]
> }
> ```
> https://ubugeeei.github.io/chibivue/10-minimum-example/040-minimum-virtual-dom.html#%E5%AE%9F%E9%9A%9B%E3%81%AB%E5%AE%9F%E8%A3%85%E3%81%97%E3%81%A6%E3%81%BF%E3%82%8B

> Colored Diffs in Code Blocks
> Adding the `// [!code --]` or `// [!code ++]` comments on a line will create a diff of that line, while keeping the colors of the codeblock.
> https://vitepress.dev/guide/markdown#colored-diffs-in-code-blocks