### PR TITLE
fix: 📌 Fixed TypeScript errors by removing unnecessary variable.

### DIFF
--- a/book/impls/10_minimum_example/040_vdom_system/packages/runtime-core/renderer.ts
+++ b/book/impls/10_minimum_example/040_vdom_system/packages/runtime-core/renderer.ts
@@ -126,7 +126,6 @@ export function createRenderer(options: RendererOptions) {
     const componentRender = rootComponent.setup!()
 
     let n1: VNode | null = null
-    let n2: VNode = null!
 
     const updateComponent = () => {
       const n2 = componentRender()

--- a/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
@@ -342,7 +342,6 @@ const render: RootRenderFunction = (rootComponent, container) => {
   const componentRender = rootComponent.setup!();
 
   let n1: VNode | null = null;
-  let n2: VNode = null!;
 
   const updateComponent = () => {
     const n2 = componentRender();

--- a/book/online-book/src/en/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/en/10-minimum-example/040-minimum-virtual-dom.md
@@ -316,7 +316,6 @@ const render: RootRenderFunction = (rootComponent, container) => {
   const componentRender = rootComponent.setup!();
 
   let n1: VNode | null = null;
-  let n2: VNode = null!;
 
   const updateComponent = () => {
     const n2 = componentRender();


### PR DESCRIPTION
When type checking is performed on the `10_minimum_example/040_vdom_system` sample code, the following error occurs.

```ts
$ pnpm tsc --noEmit --project book/impls/10_minimum_example/040_vdom_system/examples/playground/tsconfig.json
book/impls/10_minimum_example/040_vdom_system/packages/runtime-core/renderer.ts:129:9 - error TS6133: 'n2' is declared but its value is never read.

129     let n2: VNode = null!
        ~~

Found 1 error in book/impls/10_minimum_example/040_vdom_system/packages/runtime-core/renderer.ts:129
```

Therefore, unnecessary variable removed.