### PR TITLE
fix: 📌 Remove unused code in Minimum Example sample code

### DIFF
--- a/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/parse.ts
@@ -158,7 +158,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/060_template_compiler3/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/060_template_compiler3/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/060_template_compiler3/packages/runtime-core/componentOptions.ts
+++ b/book/impls/10_minimum_example/060_template_compiler3/packages/runtime-core/componentOptions.ts
@@ -1,5 +1,3 @@
-import { Data } from './component'
-
 export type ComponentOptions = {
   props?: Record<string, any>
   setup?: (

--- a/book/impls/10_minimum_example/070_sfc_compiler/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/070_sfc_compiler/packages/runtime-core/componentOptions.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler/packages/runtime-core/componentOptions.ts
@@ -1,5 +1,3 @@
-import { Data } from './component'
-
 export type ComponentOptions = {
   props?: Record<string, any>
   setup?: (

--- a/book/impls/10_minimum_example/070_sfc_compiler2/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler2/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/070_sfc_compiler2/packages/runtime-core/componentOptions.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler2/packages/runtime-core/componentOptions.ts
@@ -1,5 +1,3 @@
-import { Data } from './component'
-
 export type ComponentOptions = {
   props?: Record<string, any>
   setup?: (

--- a/book/impls/10_minimum_example/070_sfc_compiler3/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler3/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/070_sfc_compiler3/packages/runtime-core/componentOptions.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler3/packages/runtime-core/componentOptions.ts
@@ -1,5 +1,3 @@
-import { Data } from './component'
-
 export type ComponentOptions = {
   props?: Record<string, any>
   setup?: (

--- a/book/impls/10_minimum_example/070_sfc_compiler4/packages/compiler-core/parse.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler4/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/10_minimum_example/070_sfc_compiler4/packages/runtime-core/componentOptions.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler4/packages/runtime-core/componentOptions.ts
@@ -1,5 +1,3 @@
-import { Data } from './component'
-
 export type ComponentOptions = {
   props?: Record<string, any>
   setup?: (

--- a/book/online-book/src/10-minimum-example/070-more-complex-parser.md
+++ b/book/online-book/src/10-minimum-example/070-more-complex-parser.md
@@ -384,7 +384,6 @@ function parseElement(
   ancestors: ElementNode[]
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors);
   const element = parseTag(context, TagType.Start); // TODO:
 
   // <img /> のような self closing の要素の場合にはここで終了です。( children も end タグもないので)

--- a/book/online-book/src/en/10-minimum-example/070-more-complex-parser.md
+++ b/book/online-book/src/en/10-minimum-example/070-more-complex-parser.md
@@ -385,7 +385,6 @@ function parseElement(
   ancestors: ElementNode[]
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors);
   const element = parseTag(context, TagType.Start); // TODO:
 
   // If it is a self-closing element like <img />, we end here (since there are no children or end tag).


### PR DESCRIPTION
There is an unused code in Minimum Example sample code,
The following type check error occurs, so I removed it from the sample code and the documentation.

```sh
... /... /packages/compiler-core/parse.ts:201:9 - error TS6133: 'parent' is declared but its value is never read.

201 const parent = last(ancestors)
            ~~~~~~
```

```sh
../../packages/runtime-core/componentOptions.ts:1:1 - error TS6133: 'Data' is declared but its value is never read.

1 import { Data } from './component'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

