### PR TITLE
tweak: 🔧 Fixed typo in comment in code block diff for English version of minimum virtual DOM.

### DIFF
--- a/book/online-book/src/en/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/en/10-minimum-example/040-minimum-virtual-dom.md
@@ -216,7 +216,7 @@ export interface VNode<HostNode = RendererNode> {
   type: VNodeTypes;
   props: VNodeProps | null;
   children: VNodeNormalizedChildren;
-  el: HostNode | undefined; // [!code++]
+  el: HostNode | undefined; // [!code ++]
 }
 ```
 


### PR DESCRIPTION
> ```ts
> export interface VNode<HostNode = RendererNode> {
>  type: VNodeTypes;
>  props: VNodeProps | null;
>  children: VNodeNormalizedChildren;
>  el: HostNode | undefined; // [!code++]
> }
> ```
> https://ubugeeei.github.io/chibivue/en/10-minimum-example/040-minimum-virtual-dom.html#actual-implementation

> Colored Diffs in Code Blocks
> Adding the `// [!code --]` or `// [!code ++]` comments on a line will create a diff of that line, while keeping the colors of the codeblock.
> https://vitepress.dev/guide/markdown#colored-diffs-in-code-blocks

related PR

* https://github.com/Ubugeeei/chibivue/pull/219

There was an omission in the above correction 😭 