### PR TITLE
fix: 📌 Remove unused `generate` in Minimum Example

### DIFF
--- a/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/compile.ts
+++ b/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/compile.ts
@@ -1,4 +1,3 @@
-import { generate } from './codegen'
 import { baseParse } from './parse'
 
 export function baseCompile(template: string) {


### PR DESCRIPTION
There is an unused `generate` in the sample code `packages/compiler-core/compile.ts` in the Minimum Example, The following type check error occurs, so I removed it from the sample code.

```sh
../../packages/compiler-core/compile.ts:1:1 - error TS6133: 'generate' is declared but its value is never read.

1 import { generate } from './codegen'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in ../../packages/compiler-core/compile.ts:1
```