### PR TITLE
fix: 📌 Fixed a type error on import of `App.vue` in sample code.

### DIFF
--- a/book/impls/10_minimum_example/070_sfc_compiler/plugin-sample/src/main.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler/plugin-sample/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import './style.css'
+// @ts-ignore
 import App from './App.vue'
 import './plugin.sample.js'
 

--- a/book/impls/10_minimum_example/070_sfc_compiler2/examples/playground/src/main.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler2/examples/playground/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'chibivue'
+// @ts-ignore
 import App from './App.vue'
 
 const app = createApp(App)

--- a/book/impls/10_minimum_example/070_sfc_compiler3/examples/playground/src/main.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler3/examples/playground/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'chibivue'
+// @ts-ignore
 import App from './App.vue'
 
 const app = createApp(App)

--- a/book/impls/10_minimum_example/070_sfc_compiler4/examples/playground/src/main.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler4/examples/playground/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'chibivue'
+// @ts-ignore
 import App from './App.vue'
 
 const app = createApp(App)


### PR DESCRIPTION
fixed https://github.com/Ubugeeei/chibivue/issues/233

As shown below, a type error TS2307 occurs when importing `App.vue` in the sample code.

```sh
$ pnpm tsc --noEmit --project book/impls/10_minimum_example/070_sfc_compiler/plugin-sample/tsconfig.json
book/impls/10_minimum_example/070_sfc_compiler/plugin-sample/src/main.ts:3:17 - error TS2307: Cannot find module './App.vue' or its corresponding type declarations.

3 import App from './App.vue'
                  ~~~~~~~~~~~

Found 1 error in book/impls/10_minimum_example/070_sfc_compiler/plugin-sample/src/main.ts:3
```

`App.vue` is written in javascript and has no type definitions, so `@ts-ignore` is added to ignore type checking.