### PR TITLE
fix: 📌Fixed type error "Cannot find module 'rollup/parseAst'"

### DIFF
--- a/book/impls/00_introduction/010_project_setup/tsconfig.json
+++ b/book/impls/00_introduction/010_project_setup/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/010_create_app/tsconfig.json
+++ b/book/impls/10_minimum_example/010_create_app/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/010_create_app2/tsconfig.json
+++ b/book/impls/10_minimum_example/010_create_app2/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/020_simple_h_function/tsconfig.json
+++ b/book/impls/10_minimum_example/020_simple_h_function/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/030_reactive_system/tsconfig.json
+++ b/book/impls/10_minimum_example/030_reactive_system/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/040_vdom_system/tsconfig.json
+++ b/book/impls/10_minimum_example/040_vdom_system/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/050_component_system/tsconfig.json
+++ b/book/impls/10_minimum_example/050_component_system/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/050_component_system2/tsconfig.json
+++ b/book/impls/10_minimum_example/050_component_system2/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/050_component_system3/tsconfig.json
+++ b/book/impls/10_minimum_example/050_component_system3/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/060_template_compiler/tsconfig.json
+++ b/book/impls/10_minimum_example/060_template_compiler/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/060_template_compiler2/tsconfig.json
+++ b/book/impls/10_minimum_example/060_template_compiler2/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/060_template_compiler3/tsconfig.json
+++ b/book/impls/10_minimum_example/060_template_compiler3/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/070_sfc_compiler/tsconfig.json
+++ b/book/impls/10_minimum_example/070_sfc_compiler/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/070_sfc_compiler2/tsconfig.json
+++ b/book/impls/10_minimum_example/070_sfc_compiler2/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/070_sfc_compiler3/tsconfig.json
+++ b/book/impls/10_minimum_example/070_sfc_compiler3/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/10_minimum_example/070_sfc_compiler4/tsconfig.json
+++ b/book/impls/10_minimum_example/070_sfc_compiler4/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/20_basic_virtual_dom/010_patch_keyed_children/tsconfig.json
+++ b/book/impls/20_basic_virtual_dom/010_patch_keyed_children/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/20_basic_virtual_dom/020_bit_flags/tsconfig.json
+++ b/book/impls/20_basic_virtual_dom/020_bit_flags/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/20_basic_virtual_dom/040_scheduler/tsconfig.json
+++ b/book/impls/20_basic_virtual_dom/040_scheduler/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/20_basic_virtual_dom/050_next_tick/tsconfig.json
+++ b/book/impls/20_basic_virtual_dom/050_next_tick/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/20_basic_virtual_dom/060_other_props/tsconfig.json
+++ b/book/impls/20_basic_virtual_dom/060_other_props/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/010_ref/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/010_ref/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/020_shallow_ref/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/020_shallow_ref/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/030_to_ref/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/030_to_ref/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/040_to_refs/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/040_to_refs/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/050_computed/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/050_computed/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/060_computed_setter/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/060_computed_setter/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/070_watch/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/070_watch/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/080_watch_api_extends/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/080_watch_api_extends/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/090_watch_effect/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/090_watch_effect/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/110_template_refs/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/110_template_refs/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/130_cleanup_effects/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/130_cleanup_effects/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/140_effect_scope/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/140_effect_scope/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/30_basic_reactivity_system/150_other_apis/tsconfig.json
+++ b/book/impls/30_basic_reactivity_system/150_other_apis/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/010_lifecycle_hooks/tsconfig.json
+++ b/book/impls/40_basic_component_system/010_lifecycle_hooks/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/020_provide_inject/tsconfig.json
+++ b/book/impls/40_basic_component_system/020_provide_inject/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/030_component_proxy/tsconfig.json
+++ b/book/impls/40_basic_component_system/030_component_proxy/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/040_setup_context/tsconfig.json
+++ b/book/impls/40_basic_component_system/040_setup_context/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/050_component_slot/tsconfig.json
+++ b/book/impls/40_basic_component_system/050_component_slot/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/060_slot_extend/tsconfig.json
+++ b/book/impls/40_basic_component_system/060_slot_extend/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/40_basic_component_system/070_options_api/tsconfig.json
+++ b/book/impls/40_basic_component_system/070_options_api/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/010_transformer/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/010_transformer/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/020_v_bind/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/020_v_bind/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/022_transform_expression/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/022_transform_expression/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/025_v_on/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/025_v_on/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/027_event_modifier/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/027_event_modifier/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/027_event_modifier2/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/027_event_modifier2/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/030_fragment/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/030_fragment/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/035_comment/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/035_comment/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/050_v_for/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/050_v_for/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/50_basic_template_compiler/060_resolve_components/tsconfig.json
+++ b/book/impls/50_basic_template_compiler/060_resolve_components/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/impls/bonus/hyper-ultimate-super-extreme-minimal-vue/tsconfig.json
+++ b/book/impls/bonus/hyper-ultimate-super-extreme-minimal-vue/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "hyper-ultimate-super-extreme-minimal-vue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/online-book/src/00-introduction/040-setup-project.md
+++ b/book/online-book/src/00-introduction/040-setup-project.md
@@ -123,7 +123,7 @@ tsconfig.json の内容
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },

--- a/book/online-book/src/en/00-introduction/040-setup-project.md
+++ b/book/online-book/src/en/00-introduction/040-setup-project.md
@@ -108,7 +108,7 @@ Contents of tsconfig.json
     "paths": {
       "chibivue": ["./packages"]
     },
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
fixed: https://github.com/Ubugeeei/chibivue/issues/237

As shown below, a type error TS2307 occurs in `vite@5.0.10`.

```sh
$ cd book/impls/10_minimum_example/070_sfc_compiler2
$ pnpm install
$ pnpm tsc --noEmit

../../../../node_modules/.pnpm/vite@5.0.10_@types+node@20.10.5/node_modules/vite/dist/node/index.d.ts:6:41 - error TS2307: Cannot find module 'rollup/parseAst' or its corresponding type declarations.

6 export { parseAst, parseAstAsync } from 'rollup/parseAst';
                                          ~~~~~~~~~~~~~~~~~

Found 1 error in ../../../../node_modules/.pnpm/vite@5.0.10_@types+node@20.10.5/node_modules/vite/dist/node/index.d.ts:6
```

Therefore, changed `moduleResolution` to `bundler`.