### PR TITLE
update: contrast ratio of VPButton colors on the top page to meet the WCAG standards

### DIFF
--- a/book/online-book/.vitepress/theme/main.css
+++ b/book/online-book/.vitepress/theme/main.css
@@ -9,8 +9,8 @@
   --c-blue-light: #5e9ab5;
   --c-blue-lighter: #7fb1c2;
 
-  --c-teal: #086367;
-  --c-teal-light: #33898d;
+  --c-teal: #0c5053;
+  --c-teal-light: #27696d;
 
   --c-white-dark: #f8f8f8;
   --vp-c-black-darker: #0d121b;
@@ -89,15 +89,12 @@ html.dark:root {
  * -------------------------------------------------------------------------- */
 
 :root {
-  --vp-button-brand-border: var(--c-blue-dark);
-  --vp-button-brand-text: var(--vp-c-brand-text);
-  --vp-button-brand-bg: var(--c-blue);
-  --vp-button-brand-hover-border: var(--c-blue-light);
-  --vp-button-brand-hover-text: var(--vp-c-brand-text);
-  --vp-button-brand-hover-bg: var(--c-blue-light);
-  --vp-button-brand-active-border: var(--c-blue-dark);
-  --vp-button-brand-active-text: var(--vp-c-brand-text);
-  --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-bg: var(--c-teal-light);
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-hover-bg: var(--c-teal);
+  --vp-button-brand-active-border: transparent;
+  --vp-button-brand-active-bg: var(--c-teal-light);
 }
 
 /**


### PR DESCRIPTION
resolve #244 

The colors of `--c-teal` and `--c-teal-light` have been adjusted and adopted as the link button colors.

| dark mode | light mode |
|-------------|--------------|
| ![Screenshot of the hero image section of the chibivue TOP page (in dark mode)](https://github.com/Ubugeeei/chibivue/assets/1996642/99eb67d7-e30c-414e-8b1e-4adfc6205f41) | ![Screenshot of the hero image section of the chibivue TOP page (in light mode)](https://github.com/Ubugeeei/chibivue/assets/1996642/c0a3a872-15c1-4fb9-9996-2722e4e3a2c7) |

Each of the link button colors also meets the `4.5:1` color contrast ratio required by WCAG [^1].

[^1]: [Understanding Success Criterion 1.4.3: Contrast (Minimum) | WAI | W3C](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)

| Default, Active Color | Hover Color |
|---------------------|----------|
| ![Contrast ratio of background to text color for VPButton in default and active state is 6.31](https://github.com/Ubugeeei/chibivue/assets/1996642/1cc71226-f6c6-4604-b5ed-9bb6e2ccd54d) | ![Contrast ratio of background to text color for VPButton in hover state is 9.17](https://github.com/Ubugeeei/chibivue/assets/1996642/98fb0e43-0bc2-4b9b-8460-0fa028edde97) | 