### PR TITLE
fix: 📌 Remove unused `parent` in sample codes.

### DIFF
--- a/book/impls/20_basic_virtual_dom/010_patch_keyed_children/packages/compiler-core/parse.ts
+++ b/book/impls/20_basic_virtual_dom/010_patch_keyed_children/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/20_basic_virtual_dom/020_bit_flags/packages/compiler-core/parse.ts
+++ b/book/impls/20_basic_virtual_dom/020_bit_flags/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/20_basic_virtual_dom/040_scheduler/packages/compiler-core/parse.ts
+++ b/book/impls/20_basic_virtual_dom/040_scheduler/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/20_basic_virtual_dom/050_next_tick/packages/compiler-core/parse.ts
+++ b/book/impls/20_basic_virtual_dom/050_next_tick/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/20_basic_virtual_dom/060_other_props/packages/compiler-core/parse.ts
+++ b/book/impls/20_basic_virtual_dom/060_other_props/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/010_ref/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/010_ref/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/020_shallow_ref/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/020_shallow_ref/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/030_to_ref/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/030_to_ref/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/040_to_refs/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/040_to_refs/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/050_computed/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/050_computed/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/060_computed_setter/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/060_computed_setter/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/070_watch/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/070_watch/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/080_watch_api_extends/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/080_watch_api_extends/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/090_watch_effect/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/090_watch_effect/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/110_template_refs/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/110_template_refs/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/130_cleanup_effects/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/130_cleanup_effects/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/140_effect_scope/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/140_effect_scope/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/30_basic_reactivity_system/150_other_apis/packages/compiler-core/parse.ts
+++ b/book/impls/30_basic_reactivity_system/150_other_apis/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/010_lifecycle_hooks/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/010_lifecycle_hooks/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/020_provide_inject/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/020_provide_inject/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/030_component_proxy/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/030_component_proxy/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/040_setup_context/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/040_setup_context/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/050_component_slot/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/050_component_slot/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/060_slot_extend/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/060_slot_extend/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/40_basic_component_system/070_options_api/packages/compiler-core/parse.ts
+++ b/book/impls/40_basic_component_system/070_options_api/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/010_transformer/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/010_transformer/packages/compiler-core/parse.ts
@@ -198,7 +198,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/020_v_bind/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/020_v_bind/packages/compiler-core/parse.ts
@@ -200,7 +200,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/022_transform_expression/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/022_transform_expression/packages/compiler-core/parse.ts
@@ -205,7 +205,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/025_v_on/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/025_v_on/packages/compiler-core/parse.ts
@@ -205,7 +205,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/027_event_modifier/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/027_event_modifier/packages/compiler-core/parse.ts
@@ -205,7 +205,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/027_event_modifier2/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/027_event_modifier2/packages/compiler-core/parse.ts
@@ -205,7 +205,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/030_fragment/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/030_fragment/packages/compiler-core/parse.ts
@@ -205,7 +205,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/035_comment/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/035_comment/packages/compiler-core/parse.ts
@@ -250,7 +250,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/packages/compiler-core/parse.ts
@@ -250,7 +250,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/050_v_for/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/050_v_for/packages/compiler-core/parse.ts
@@ -250,7 +250,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {

--- a/book/impls/50_basic_template_compiler/060_resolve_components/packages/compiler-core/parse.ts
+++ b/book/impls/50_basic_template_compiler/060_resolve_components/packages/compiler-core/parse.ts
@@ -276,7 +276,6 @@ function parseElement(
   ancestors: ElementNode[],
 ): ElementNode | undefined {
   // Start tag.
-  const parent = last(ancestors)
   const element = parseTag(context, TagType.Start) // TODO:
 
   if (element.isSelfClosing) {


### PR DESCRIPTION
There is an unused `parent` in the sample code `packages/compiler-core/parse.ts`, 
The following type check error occurs, so I removed it from the sample code.

```sh
../../packages/compiler-core/parse.ts:201:9 - error TS6133: 'parent' is declared but its value is never read.

201   const parent = last(ancestors)
```
