### PR TITLE
update:Change screen state to  "Generate render function based on AST"

### DIFF
--- a/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/codegen.ts
+++ b/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/codegen.ts
@@ -1,16 +1,33 @@
+import { ElementNode, NodeTypes, TemplateChildNode, TextNode } from './ast'
+
 export const generate = ({
-  tag,
-  props,
-  textContent,
+  children,
 }: {
-  tag: string
-  props: Record<string, string>
-  textContent: string
+  children: TemplateChildNode[]
 }): string => {
-  return `return () => {
+  return `return function render() {
   const { h } = ChibiVue;
-  return h("${tag}", { ${Object.entries(props)
-    .map(([k, v]) => `${k}: "${v}"`)
-    .join(', ')} }, ["${textContent}"]);
+  return ${genNode(children[0])};
 }`
+}
+
+const genNode = (node: TemplateChildNode): string => {
+  switch (node.type) {
+    case NodeTypes.ELEMENT:
+      return genElement(node)
+    case NodeTypes.TEXT:
+      return genText(node)
+    default:
+      return ''
+  }
+}
+
+const genElement = (el: ElementNode): string => {
+  return `h("${el.tag}", {${el.props
+    .map(({ name, value }) => `${name}: "${value?.content}"`)
+    .join(', ')}}, [${el.children.map(it => genNode(it)).join(', ')}])`
+}
+
+const genText = (text: TextNode): string => {
+  return `\`${text.content}\``
 }

--- a/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/compile.ts
+++ b/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/compile.ts
@@ -1,14 +1,8 @@
+import { generate } from './codegen'
 import { baseParse } from './parse'
 
 export function baseCompile(template: string) {
   const parseResult = baseParse(template.trim())
-  console.log(
-    '🚀 ~ file: compile.ts:6 ~ baseCompile ~ parseResult:',
-    parseResult,
-  )
-
-  // TODO: codegen
-  // const code = generate(parseResult);
-  // return code;
-  return ''
+  const code = generate(parseResult)
+  return code
 }


### PR DESCRIPTION
[changes]  
Reflects changes in chapter  ”[Generating the render function based on the AST](https://ubugeeei.github.io/chibivue/en/10-minimum-example/070-more-complex-parser.html#generating-the-render-function-based-on-the-ast)”.
Currently, the code is at chapter "[After finishing the implementation of the parser](https://ubugeeei.github.io/chibivue/en/10-minimum-example/070-more-complex-parser.html#after-finishing-the-implementation-of-the-parser)"

| before | After |
| ------ | ----- |
| ![image](https://github.com/Ubugeeei/chibivue/assets/47783146/9f90ab16-4c03-401b-8664-e029eead2c3d) | ![image](https://github.com/Ubugeeei/chibivue/assets/47783146/b396fecb-4f5a-4fb6-8409-706c7db4a194) |


[background]
I was going to write a test for "10_minimum_example/060_template_compiler2" but noticed nothing on the screen.
I think the cause is that there is no processing in the code to reflect the ”[Generating the render function based on the AST](https://ubugeeei.github.io/chibivue/en/10-minimum-example/070-more-complex-parser.html#generating-the-render-function-based-on-the-ast)”.

related: https://github.com/Ubugeeei/chibivue/issues/255


