### PR TITLE
fix: Fix multiple file paths in `fs.readFileSync`

### DIFF
--- a/book/impls/10_minimum_example/070_sfc_compiler4/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/10_minimum_example/070_sfc_compiler4/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/20_basic_virtual_dom/010_patch_keyed_children/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/20_basic_virtual_dom/010_patch_keyed_children/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/20_basic_virtual_dom/020_bit_flags/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/20_basic_virtual_dom/020_bit_flags/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/20_basic_virtual_dom/040_scheduler/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/20_basic_virtual_dom/040_scheduler/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/20_basic_virtual_dom/050_next_tick/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/20_basic_virtual_dom/050_next_tick/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/20_basic_virtual_dom/060_other_props/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/20_basic_virtual_dom/060_other_props/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/020_shallow_ref/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/020_shallow_ref/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/030_to_ref/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/030_to_ref/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/040_to_refs/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/040_to_refs/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/050_computed/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/050_computed/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/060_computed_setter/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/060_computed_setter/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/070_watch/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/070_watch/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/080_watch_api_extends/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/080_watch_api_extends/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/090_watch_effect/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/090_watch_effect/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/100_reactive_proxy_target_type/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/110_template_refs/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/110_template_refs/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/120_proxy_handler_improvement/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/130_cleanup_effects/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/130_cleanup_effects/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/140_effect_scope/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/140_effect_scope/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/30_basic_reactivity_system/150_other_apis/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/30_basic_reactivity_system/150_other_apis/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/010_lifecycle_hooks/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/010_lifecycle_hooks/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/020_provide_inject/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/020_provide_inject/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/030_component_proxy/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/030_component_proxy/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/040_setup_context/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/040_setup_context/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/050_component_slot/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/050_component_slot/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/060_slot_extend/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/060_slot_extend/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/40_basic_component_system/070_options_api/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/40_basic_component_system/070_options_api/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/010_transformer/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/010_transformer/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/020_v_bind/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/020_v_bind/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/022_transform_expression/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/022_transform_expression/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/025_v_on/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/025_v_on/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/027_event_modifier/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/027_event_modifier/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/027_event_modifier2/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/027_event_modifier2/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/030_fragment/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/030_fragment/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/035_comment/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/035_comment/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/040_v_if_and_structural_directive/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/050_v_for/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/050_v_for/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/impls/50_basic_template_compiler/060_resolve_components/packages/@extensions/vite-plugin-chibivue/index.ts
+++ b/book/impls/50_basic_template_compiler/060_resolve_components/packages/@extensions/vite-plugin-chibivue/index.ts
@@ -16,7 +16,7 @@ export default function vitePluginChibivue(): Plugin {
     load(id) {
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8')
+        const content = fs.readFileSync(filename, 'utf-8')
         const { descriptor } = parse(content, { filename })
         const styles = descriptor.styles.map(it => it.content).join('\n')
         return { code: styles }

--- a/book/online-book/src/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/10-minimum-example/090-minimum-sfc.md
@@ -1306,7 +1306,7 @@ export default function vitePluginChibivue(): Plugin {
       // .vue.cssがloadされた (importが宣言され、読み込まれた) ときのハンドリング
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8') // 普通にSFCファイルを取得
+        const content = fs.readFileSync(filename, 'utf-8') // 普通にSFCファイルを取得
         const { descriptor } = parse(content, { filename }) //  SFCをパース
 
         // contentをjoinsして結果とする。

--- a/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
@@ -1264,7 +1264,7 @@ export default function vitePluginChibivue(): Plugin {
       // Handling when .vue.css is loaded (when import is declared and loaded)
       if (id.match(/\.vue\.css$/)) {
         const filename = id.replace(/\.css$/, '')
-        const content = fs.readFileSync('.' + filename, 'utf-8') // Retrieve the SFC file normally
+        const content = fs.readFileSync(filename, 'utf-8') // Retrieve the SFC file normally
         const { descriptor } = parse(content, { filename }) // Parse the SFC
 
         // Join the content and return it as the result


### PR DESCRIPTION
resolve: #234 

The `.` in front of filename in the file reading function `fs.readFileSync` has been removed.
Since `filename` is an absolute path, a `.` before filename prevents fs from resolving the file.

I've fixed this because currently the output is different from what the documentation expects, forcing users to handle unnecessary errors.

The old code was:

```ts
const content = fs.readFileSync('.' + filename, 'utf-8')
```

<img width="2000" alt="Screenshot 2024-02-18 at 16 08 52" src="https://github.com/Ubugeeei/chibivue/assets/58300794/bef2eee1-117c-40bd-ad25-eef1a3aed410">

This has now been fixed to:

```ts
const content = fs.readFileSync(filename, 'utf-8')
```

<img width="2000" alt="Screenshot 2024-02-18 at 16 08 41" src="https://github.com/Ubugeeei/chibivue/assets/58300794/93b5596d-6384-4ec2-811b-5085dc4882b9">
