### PR TITLE
fix: 📌 Fixed typo and tweaked wording in more complex HTML.

### DIFF
--- a/book/online-book/src/10-minimum-example/070-more-complex-parser.md
+++ b/book/online-book/src/10-minimum-example/070-more-complex-parser.md
@@ -306,7 +306,7 @@ function isEnd(context: ParserContext, ancestors: ElementNode[]): boolean {
 
 ## parseText
 
-まずはシンプルな parseText の方から.一部、parseText 以外でも使うユーティリティも実装しているので少しだけ長いです。
+まずはシンプルな parseText の方から実装していきます。一部、parseText 以外でも使うユーティリティも実装しているので少しだけ長いです。
 
 ```ts
 function parseText(context: ParserContext): TextNode {


### PR DESCRIPTION
Fixed a minor typo and tweaked wording found in the chapter in more complex HTML.

> まずはシンプルな parseText の方から.一部、parseText 以外でも使うユーティリティも実装しているので少しだけ長いです。
> https://ubugeeei.github.io/chibivue/10-minimum-example/070-more-complex-parser.html#parsetext