### PR TITLE
fix: 📌 Added the implementation of advanceSpaces to the sample code in the document.

### DIFF
--- a/book/online-book/src/10-minimum-example/070-more-complex-parser.md
+++ b/book/online-book/src/10-minimum-example/070-more-complex-parser.md
@@ -345,6 +345,13 @@ function advanceBy(context: ParserContext, numberOfCharacters: number): void {
   context.source = source.slice(numberOfCharacters)
 }
 
+function advanceSpaces(context: ParserContext): void {
+  const match = /^[\t\r\n\f ]+/.exec(context.source);
+  if (match) {
+    advanceBy(context, match[0].length);
+  }
+}
+
 // 少し長いですが、やっていることは単純で、 pos の計算を行っています。
 // 引数でもらった pos のオブジェクトを破壊的に更新しています。
 function advancePositionWithMutation(

--- a/book/online-book/src/en/10-minimum-example/070-more-complex-parser.md
+++ b/book/online-book/src/en/10-minimum-example/070-more-complex-parser.md
@@ -346,6 +346,13 @@ function advanceBy(context: ParserContext, numberOfCharacters: number): void {
   context.source = source.slice(numberOfCharacters)
 }
 
+function advanceSpaces(context: ParserContext): void {
+  const match = /^[\t\r\n\f ]+/.exec(context.source);
+  if (match) {
+    advanceBy(context, match[0].length);
+  }
+}
+
 // Although it is a bit long, it simply calculates the position.
 // It destructively updates the pos object received as an argument.
 function advancePositionWithMutation(


### PR DESCRIPTION
There is a place where `advanceSpaces` is called in the implementation of `parseTag`, but since the implementation of `advanceSpaces` did not exist in the document, I added the implementation of `advanceSpaces` to the utilities in the sample code of the `parseText` implementation.

```ts
function parseTag(context: ParserContext, type: TagType): ElementNode {
  // Tag open.
  const start = getCursor(context)
  const match = /^<\/?([a-z][^\t\r\n\f />]*)/i.exec(context.source)!
  const tag = match[1]

  advanceBy(context, match[0].length)
  advanceSpaces(context)
```

ref: https://ubugeeei.github.io/chibivue/10-minimum-example/070-more-complex-parser.html#parseelement

I referred to the following description for the implementation of advanceSpaces.

https://github.com/Ubugeeei/chibivue/blob/v0.0.8/book/impls/10_minimum_example/060_template_compiler2/packages/compiler-core/parse.ts#L112-L117