### PR TITLE
fix: typo

### DIFF
--- a/book/online-book/src/10-minimum-example/020-simple-h-function.md
+++ b/book/online-book/src/10-minimum-example/020-simple-h-function.md
@@ -378,8 +378,8 @@ export function patchEvent(
   }
 }
 
-function parseName(rowName: string): string {
-  return rowName.slice(2).toLocaleLowerCase()
+function parseName(rawName: string): string {
+  return rawName.slice(2).toLocaleLowerCase()
 }
 
 function createInvoker(initialValue: EventValue) {


### PR DESCRIPTION
Based on the previous `parseName(rawName)`, `rowName` should be corrected to `rawName`.