### PR TITLE
fix: 📌 Fixed typo in Minimum SFC.

### DIFF
--- a/book/online-book/src/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/10-minimum-example/090-minimum-sfc.md
@@ -349,7 +349,7 @@ export default defineConfig({
 
 ![vite_error](https://raw.githubusercontent.com/Ubugeeei/chibivue/main/book/images/vite_error.png)
 
-もちろんエラーになります。やったね( ？　)
+もちろんエラーになります。やったね( ？ )
 
 ## エラーの解消
 
@@ -999,7 +999,7 @@ export default { ..._sfc_main, render }
 
 というふうに書き換えたいわけです。
 
-つまりは、元々のコードの export 文から良い感じに export 対象をを抜き出し、\_sfc_main という変数に代入できるようになればゴールということです。
+つまりは、元々のコードの export 文から良い感じに export 対象を抜き出し、\_sfc_main という変数に代入できるようになればゴールということです。
 
 まずは必要なライブラリをインストールします。
 
@@ -1283,7 +1283,7 @@ import { msg } from 'virtual:my-module'
 
 [参考](https://ja.vitejs.dev/guide/api-plugin.html#%E4%BB%AE%E6%83%B3%E3%83%A2%E3%82%B7%E3%82%99%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%AE%E8%A6%8F%E7%B4%84)
 
-子の仕組みを使って SFC の style ブロックを仮想の css ファイルとして読み込むようにしてみます。  
+この仕組みを使って SFC の style ブロックを仮想の css ファイルとして読み込むようにしてみます。  
 最初に言った通り、vite では css という拡張子のファイルを import すれば良いので、${SFC のファイル名}.css という仮想モジュールを作ることを考えてみます。
 
 ### SFC のスタイルブロックの内容で仮想モジュールを実装する


### PR DESCRIPTION
### Description

Fixed a minor typo in the chapter in Minimum SFC.

> つまりは、元々のコードの export 文から良い感じに export 対象をを抜き出し、_sfc_main という変数に代入できるようになればゴールということです。
> https://ubugeeei.github.io/chibivue/10-minimum-example/090-minimum-sfc.html#script-%E3%81%AE-default-export-%E3%82%92%E6%9B%B8%E3%81%8D%E6%8F%9B%E3%81%88%E3%82%8B

> 子の仕組みを使って SFC の style ブロックを仮想の css ファイルとして読み込むようにしてみます。
> https://ubugeeei.github.io/chibivue/10-minimum-example/090-minimum-sfc.html#%E4%BB%AE%E6%83%B3%E3%83%A2%E3%82%B7%E3%82%99%E3%83%A5%E3%83%BC%E3%83%AB

> もちろんエラーになります。やったね( ？　)
> https://ubugeeei.github.io/chibivue/10-minimum-example/090-minimum-sfc.html#%E6%BA%96%E5%82%99

### Test

I have confirmed that the check action was successful.

https://github.com/madogiwa0124/chibivue/actions/runs/8917017380/job/24489410952