### PR TITLE
fix: 📌 Fixed command in Minimum SFC.

### DIFF
--- a/book/online-book/src/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/10-minimum-example/090-minimum-sfc.md
@@ -97,7 +97,7 @@ vite のプラグインを書いたことのない方も少ないと思うので
 
 ```sh
 pwd # ~
-pnpx create-vite
+nlx create-vite
 ## ✔ Project name: … plugin-sample
 ## ✔ Select a framework: › Vue
 ## ✔ Select a variant: › TypeScript

--- a/book/online-book/src/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/10-minimum-example/090-minimum-sfc.md
@@ -226,6 +226,13 @@ pwd # ~
 rm -rf ./plugin-sample
 ```
 
+また Vite の plugin を作成するため Vite 本体をインストールしておきます。
+
+```sh
+pwd # ~
+ni vite
+```
+
 plugin の本体なのですが、本来これは vuejs/core の範囲外なので packages に`@extensions`というディレクトリを切ってそこに実装していきます。
 
 ```sh

--- a/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
@@ -96,7 +96,7 @@ Since there may be few people who have never written a Vite plugin, let's start 
 
 ```sh
 pwd # ~
-pnpx create-vite
+nlx create-vite
 ## ✔ Project name: … plugin-sample
 ## ✔ Select a framework: › Vue
 ## ✔ Select a variant: › TypeScript

--- a/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
+++ b/book/online-book/src/en/10-minimum-example/090-minimum-sfc.md
@@ -225,6 +225,13 @@ pwd # ~
 rm -rf ./plugin-sample
 ```
 
+Also, install the main Vite package in order to create a Vite plugin.
+
+```sh
+pwd # ~
+ni vite
+```
+
 This is the main part of the plugin, but since this is originally outside the scope of vuejs/core, we will create a directory called `@extensions` in the `packages` directory and implement it there.
 
 ```sh


### PR DESCRIPTION
### Description

I have made the following fix to the Minimal SFC chapter.

Fixed it to use commands with `ni`.

> nlx - download & execute
> https://github.com/antfu-collective/ni?tab=readme-ov-file#nlx---download--execute

And, added steps to install vite before creating a vite plugin
because `import type { Plugin } from 'vite'` will cause an error if vite is not installed.

> `~/packages/@extensions/vite-plugin-chibivue/index.ts`
>
> ```ts
> import type { Plugin } from 'vite'
> ```
>
> https://ubugeeei.github.io/chibivue/10-minimum-example/090-minimum-sfc.html#%E6%BA%96%E5%82%99

### Test

I have confirmed that the check action was successful.

https://github.com/madogiwa0124/chibivue/actions/runs/8917514928