### PR TITLE
fix: typo in 10-minimum-example/030-minimum-reactive.md

### DIFF
--- a/book/online-book/src/10-minimum-example/030-minimum-reactive.md
+++ b/book/online-book/src/10-minimum-example/030-minimum-reactive.md
@@ -67,7 +67,7 @@ reactive 関数でステートを定義し、それを書き換える increment 
 ## setup 関数の実装
 
 やることはとっても簡単です。
-setup オプションをを受け取り実行し、あとはそれをこれまでの render オプションと同じように使えば OK です。
+setup オプションを受け取り実行し、あとはそれをこれまでの render オプションと同じように使えば OK です。
 
 ~/packages/runtime-core/componentOptions.ts を編集します。
 


### PR DESCRIPTION
I found Japanese typo in Section 3 Minimum Reactive of Minimum Example.

I deleted duplicated「を」.

https://ubugeeei.github.io/chibivue/10-minimum-example/030-minimum-reactive.html