### PR TITLE
fix: 📌 fix file path in 060-minimum-template-compiler.md

### DIFF
--- a/book/online-book/src/10-minimum-example/060-minimum-template-compiler.md
+++ b/book/online-book/src/10-minimum-example/060-minimum-template-compiler.md
@@ -247,7 +247,7 @@ const code = `
 
 ## 実装
 
-アプローチが理解できたら早速実装してみましょう．`~/packages/src`に`compiler-core`というディレクトリを作ってそこに`index.ts`, `parse.ts`, `codegen.ts`を作成します．
+アプローチが理解できたら早速実装してみましょう．`~/packages`に`compiler-core`というディレクトリを作ってそこに`index.ts`, `parse.ts`, `codegen.ts`を作成します．
 
 ```sh
 pwd # ~/

--- a/book/online-book/src/en/10-minimum-example/060-minimum-template-compiler.md
+++ b/book/online-book/src/en/10-minimum-example/060-minimum-template-compiler.md
@@ -239,7 +239,7 @@ const code = `
 
 ## Implementation
 
-Once you understand the approach, let's implement it. Create a directory called `compiler-core` in `~/packages/src` and create `index.ts`, `parse.ts`, and `codegen.ts` in it.
+Once you understand the approach, let's implement it. Create a directory called `compiler-core` in `~/packages` and create `index.ts`, `parse.ts`, and `codegen.ts` in it.
 
 ```sh
 pwd # ~/


### PR DESCRIPTION
I have fixed the incorrect directory paths in "060-minimum-template-compiler.md".

I changed `~/packages/src` to `~/packages` in the following quoted text.

>アプローチが理解できたら早速実装してみましょう．`~/packages/src` に`compiler-core`というディレクトリを作ってそこに`index.ts`, `parse.ts`, `codegen.ts`を作成します．
>
>```sh
>pwd # ~/
>mkdir packages/compiler-core
>touch packages/compiler-core/index.ts